### PR TITLE
fix(river): Change on_delete options to CASCADE

### DIFF
--- a/river/models/hook.py
+++ b/river/models/hook.py
@@ -2,7 +2,8 @@ import logging
 
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
-from django.db.models import PROTECT
+from django.db.models import PROTECT, CASCADE
+
 try:
     # Try to import gettext_lazy for Django 3.0 and newer
     from django.utils.translation import gettext_lazy as _
@@ -28,8 +29,8 @@ class Hook(BaseModel):
     class Meta:
         abstract = True
 
-    callback_function = models.ForeignKey(Function, verbose_name=_("Function"), related_name='%(app_label)s_%(class)s_hooks', on_delete=PROTECT)
-    workflow = models.ForeignKey(Workflow, verbose_name=_("Workflow"), related_name='%(app_label)s_%(class)s_hooks', on_delete=PROTECT)
+    callback_function = models.ForeignKey(Function, verbose_name=_("Function"), related_name='%(app_label)s_%(class)s_hooks', on_delete=CASCADE)
+    workflow = models.ForeignKey(Workflow, verbose_name=_("Workflow"), related_name='%(app_label)s_%(class)s_hooks', on_delete=CASCADE)
 
     content_type = models.ForeignKey(ContentType, blank=True, null=True, on_delete=models.SET_NULL)
     object_id = models.CharField(max_length=200, blank=True, null=True)

--- a/river/models/transition.py
+++ b/river/models/transition.py
@@ -47,10 +47,10 @@ class Transition(BaseModel):
     object_id = models.CharField(max_length=50, verbose_name=_('Related Object'))
     workflow_object = GenericForeignKey('content_type', 'object_id')
 
-    meta = models.ForeignKey(TransitionMeta, verbose_name=_('Meta'), related_name="transitions", on_delete=PROTECT)
-    workflow = models.ForeignKey(Workflow, verbose_name=_("Workflow"), related_name='transitions', on_delete=PROTECT)
-    source_state = models.ForeignKey(State, verbose_name=_("Source State"), related_name='transition_as_source', on_delete=PROTECT)
-    destination_state = models.ForeignKey(State, verbose_name=_("Destination State"), related_name='transition_as_destination', on_delete=PROTECT)
+    meta = models.ForeignKey(TransitionMeta, verbose_name=_('Meta'), related_name="transitions", on_delete=CASCADE)
+    workflow = models.ForeignKey(Workflow, verbose_name=_("Workflow"), related_name='transitions', on_delete=CASCADE)
+    source_state = models.ForeignKey(State, verbose_name=_("Source State"), related_name='transition_as_source', on_delete=CASCADE)
+    destination_state = models.ForeignKey(State, verbose_name=_("Destination State"), related_name='transition_as_destination', on_delete=CASCADE)
 
     status = models.CharField(_('Status'), choices=STATUSES, max_length=100, default=PENDING)
 

--- a/river/models/transitionapproval.py
+++ b/river/models/transitionapproval.py
@@ -52,9 +52,9 @@ class TransitionApproval(BaseModel):
     workflow_object = GenericForeignKey('content_type', 'object_id')
 
     meta = models.ForeignKey(TransitionApprovalMeta, verbose_name=_('Meta'), related_name="transition_approvals", null=True, blank=True, on_delete=SET_NULL)
-    workflow = models.ForeignKey(Workflow, verbose_name=_("Workflow"), related_name='transition_approvals', on_delete=PROTECT)
+    workflow = models.ForeignKey(Workflow, verbose_name=_("Workflow"), related_name='transition_approvals', on_delete=CASCADE)
 
-    transition = models.ForeignKey(Transition, verbose_name=_("Transition"), related_name='transition_approvals', on_delete=PROTECT)
+    transition = models.ForeignKey(Transition, verbose_name=_("Transition"), related_name='transition_approvals', on_delete=CASCADE)
 
     transactioner = models.ForeignKey(app_config.USER_CLASS, verbose_name=_('Transactioner'), null=True, blank=True, on_delete=SET_NULL)
     transaction_date = models.DateTimeField(null=True, blank=True)

--- a/river/models/transitionapprovalmeta.py
+++ b/river/models/transitionapprovalmeta.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from django.db import models, transaction
-from django.db.models import PROTECT
+from django.db.models import PROTECT, CASCADE
 from django.db.models.signals import post_save, pre_delete
 try:
     # Try to import gettext_lazy for Django 3.0 and newer
@@ -26,9 +26,9 @@ class TransitionApprovalMeta(BaseModel):
 
     objects = TransitionApprovalMetadataManager()
 
-    workflow = models.ForeignKey(Workflow, verbose_name=_("Workflow"), related_name='transition_approval_metas', on_delete=PROTECT)
+    workflow = models.ForeignKey(Workflow, verbose_name=_("Workflow"), related_name='transition_approval_metas', on_delete=CASCADE)
 
-    transition_meta = models.ForeignKey(TransitionMeta, verbose_name=_("Transition Meta"), related_name='transition_approval_meta', on_delete=PROTECT)
+    transition_meta = models.ForeignKey(TransitionMeta, verbose_name=_("Transition Meta"), related_name='transition_approval_meta', on_delete=CASCADE)
 
     permissions = models.ManyToManyField(app_config.PERMISSION_CLASS, verbose_name=_('Permissions'), blank=True)
     groups = models.ManyToManyField(app_config.GROUP_CLASS, verbose_name=_('Groups'), blank=True)

--- a/river/models/transitionmeta.py
+++ b/river/models/transitionmeta.py
@@ -1,7 +1,8 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.db.models import PROTECT
+from django.db.models import PROTECT, CASCADE
+
 try:
     # Try to import gettext_lazy for Django 3.0 and newer
     from django.utils.translation import gettext_lazy as _
@@ -20,9 +21,9 @@ class TransitionMeta(BaseModel):
         verbose_name_plural = _("Transition Meta")
         unique_together = [('workflow', 'source_state', 'destination_state')]
 
-    workflow = models.ForeignKey(Workflow, verbose_name=_("Workflow"), related_name='transition_metas', on_delete=PROTECT)
-    source_state = models.ForeignKey(State, verbose_name=_("Source State"), related_name='transition_meta_as_source', on_delete=PROTECT)
-    destination_state = models.ForeignKey(State, verbose_name=_("Destination State"), related_name='transition_meta_as_destination', on_delete=PROTECT)
+    workflow = models.ForeignKey(Workflow, verbose_name=_("Workflow"), related_name='transition_metas', on_delete=CASCADE)
+    source_state = models.ForeignKey(State, verbose_name=_("Source State"), related_name='transition_meta_as_source', on_delete=CASCADE)
+    destination_state = models.ForeignKey(State, verbose_name=_("Destination State"), related_name='transition_meta_as_destination', on_delete=CASCADE)
 
     def __str__(self):
         return 'Field Name:%s, %s -> %s' % (


### PR DESCRIPTION
The ForeignKey delete options for all models in the 'river' app have been updated to use CASCADE instead of PROTECT. This means that when the referenced object is deleted, also delete the objects that have references to them. This behaviour is more in line with typical database operations.